### PR TITLE
Release/1.0.2

### DIFF
--- a/streamtools/producers.py
+++ b/streamtools/producers.py
@@ -207,6 +207,9 @@ class RMQIOProducer(ProducerABC):
         self.routing_key += f"-{self.key[:5]}"
 
     async def send(self, msg, *args, **kwargs):
+        if self.channel.is_closed:
+            self.channel = await self.connection.channel()
+
         await self.channel.default_exchange.publish(
             aio_pika.Message(
                 body=msg.encode()


### PR DESCRIPTION
### Description
This PR pulls in a hotfix for code breaking after any python `Exception` is thrown within code that uses a long-running `RMQIOProducer` object for producing messages. 

The reason was that the channel was being closed by the broker on `Exception`

The fix was to check if a channel is closed and open a new one if so before producing each message now.