### PR TITLE
(CP-1826) Standardise the interface for decorated consumer methods

### DIFF
--- a/streamtools/consumers.py
+++ b/streamtools/consumers.py
@@ -12,7 +12,8 @@ from aiohttp import web
 from aiokafka import AIOKafkaConsumer
 import aio_pika
 
-from .libs import log, clean_queue_label, get_free_port, check_queue_type, AsyncioQueue, ClassRouteTableDef
+from .libs import log, log_error, TRACEBACK, clean_queue_label, get_free_port, \
+                  check_queue_type, AsyncioQueue, ClassRouteTableDef
 from .libs import ENCODING, RMQ_USER, RMQ_PASS, RMQ_HOST, KAFKA_HOST
 
 
@@ -105,6 +106,7 @@ class ConsumerABC(ABC):
                     "'self/cls' argument not being consistently passed into class method"
                 await func(self_obj, msg)
             except AssertionError as e:
+                error_msg = log_error(e, with_traceback=TRACEBACK)
                 await func(self.self_obj, msg)
         else:
             await func(msg)

--- a/streamtools/libs.py
+++ b/streamtools/libs.py
@@ -24,6 +24,16 @@ RMQ_HOST = os.environ.get("RMQ_HOST", IP)
 HTTP_HOST = os.environ.get("HTTP_HOST", f"{IP}:3000")  # includes port for HTTP
 KAFKA_HOST = os.environ.get("KAFKA_HOST", f"{IP}:9092")  # includes port for Kafka
 
+TRACEBACK = bool(os.environ.get('TRACEBACK', True))
+
+def log_error(error, with_traceback=TRACEBACK):
+    if not with_traceback:
+        log.error(f"{type(error).__name__}: {error}")
+    else:
+        traceback_msg = f"Printing traceback for error: \"{error}\":\n{traceback.format_exc()}"
+        log.error(traceback_msg)
+
+    return str(error)
 
 def clean_queue_label(string):
     pattern = re.compile('[^a-zA-Z0-9-_]+', re.UNICODE)


### PR DESCRIPTION
_Fixes [CP-1826](https://persistolabs.atlassian.net/browse/CP-1826)_

### Description
This fix standardises the interface for decorated consumer methods and includes multiple checks to enforce this interface within the `ConsumerABC` base class.

The interface is now strictly only 1 non-keyword 'message' param, and an additional `self/cls` param for if the decorated method is being declared inside a class.

### Reviewers
- @DarionHernandez (merge duty)
- @louisnk
- ...
