### PR TITLE
(CP-2686) Revert "(CP-2276) Remove deletion of consumer msgs for SQS consumer"

### DIFF
--- a/streamtools/consumers.py
+++ b/streamtools/consumers.py
@@ -134,10 +134,6 @@ class ConsumerABC(ABC):
                 '''
                 while True:
                     async for msg in self.consumer:
-                        msg = {
-                            "queue_type": self.QUEUE_TYPE[0],
-                            "msg": msg
-                        }
                         # Decorated function 'func' comes in here
                         await self.call_decorated(func, msg, w_args, w_kwargs)
 
@@ -191,10 +187,6 @@ class KafkaConsumerLoop(ConsumerABC):
                                 if not isinstance(msg, (str, bytes, bytearray)) \
                                 else msg
 
-                            msg = {
-                                "queue_type": self.QUEUE_TYPE[0],
-                                "msg": msg
-                            }
                             # Decorated function 'func' comes in here
                             await self.call_decorated(func, msg, w_args, w_kwargs)
 
@@ -221,10 +213,6 @@ class AsyncIOConsumerLoop(ConsumerABC):
                 """
                 while True:
                     async for msg in self.consumer:
-                        msg = {
-                            "queue_type": self.QUEUE_TYPE[0],
-                            "msg": msg
-                        }
                         # Decorated function 'func' comes in here
                         await self.call_decorated(func, msg, w_args, w_kwargs)
 
@@ -273,16 +261,13 @@ class SQSConsumerLoop(ConsumerABC):
                                     log.info(f"SQS message received: {msg}")
                                     msg_body = msg.get('Body')
                                     log.info(f"Message body: {msg_body}")
-                                    msg = {
-                                        "queue_type": self.QUEUE_TYPE[0],
-                                        "msg": msg_body,
-                                        "delete_func": client.delete_message,
-                                        "QueueUrl": queue_url,
-                                        "ReceiptHandle": msg['ReceiptHandle'],
-                                    }
                                     # Decorated function 'func' comes in here
-                                    await self.call_decorated(func, msg, w_args, w_kwargs)
+                                    await self.call_decorated(func, msg_body, w_args, w_kwargs)
 
+                                    await client.delete_message(
+                                        QueueUrl=queue_url,
+                                        ReceiptHandle=msg['ReceiptHandle']
+                                    )
                         except Exception as e:
                             pass
 
@@ -353,10 +338,8 @@ class RMQIOConsumerLoop(ConsumerABC):
                         # Cancel consuming after __aexit__
                         async for msg in consumer:
                             async with msg.process():
-                                msg = {
-                                    "queue_type": self.QUEUE_TYPE[0],
-                                    "msg": msg.body
-                                }
+                                msg = msg.body
+
                                 # Decorated function 'func' comes in here
                                 await self.call_decorated(func, msg, w_args, w_kwargs)
 


### PR DESCRIPTION
Reverts CariPay/streamtools#13

The first attempt (PR #15) was messed up because the revert was started on an already rebased `develop` branch and so had no changes on it revert branch.

The reversion diff (_[see here](https://github.com/CariPay/streamtools/compare/1e9fed9bba38e0650d6f5115638b312247072c89...09713368e3af98edeafc3a40b030b2ab5a121a25), compare of #16 to #12_) is now empty which is what is expected.

---

### CP-2686 notes

Maintaining compatibility with current releases:

- `ocr` repo is currently released to the tip of PR #12, so reverting PR #13 does not affect it in any way

- `pipeline-serverless` is currently released to commit [3e6f709](https://github.com/CariPay/streamtools/commit/3e6f709055c29a78a8dc84b6ffcba76252fd0dfb) on develop which was part of PR #13. It only relies on **Producer** code though and so does not need any of the code changes implemented in PR #13. It does still require the commit hash from that branch though which is why we reverted here instead of simply rebasing the whole PR #13 branch off `develop`
